### PR TITLE
[campaignion_conf] Set "full content" for images

### DIFF
--- a/modules/campaignion_conf/campaignion_conf.file_default_displays.inc
+++ b/modules/campaignion_conf/campaignion_conf.file_default_displays.inc
@@ -23,6 +23,17 @@ function campaignion_conf_file_default_displays() {
 
   $file_display = new stdClass();
   $file_display->api_version = 1;
+  $file_display->name = 'image__full__file_field_image';
+  $file_display->weight = -1;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'image_style' => '',
+    'image_link' => '',
+  );
+  $export['image__full__file_field_image'] = $file_display;
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
   $file_display->name = 'image__preview__file_field_image';
   $file_display->weight = 0;
   $file_display->status = TRUE;

--- a/modules/campaignion_conf/campaignion_conf.info
+++ b/modules/campaignion_conf/campaignion_conf.info
@@ -19,6 +19,7 @@ features[ctools][] = file_entity:file_default_displays:1
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[file_display][] = image__default__file_field_image
+features[file_display][] = image__full__file_field_image
 features[file_display][] = image__preview__file_field_image
 features[file_display][] = image__teaser__file_field_image
 features[file_display][] = video__default__media_vimeo_image


### PR DESCRIPTION
Set "full content" display for image files to display the original image on the file page (without applying any image styles).
