### PR TITLE
[templates] Fix confirm_url token

### DIFF
--- a/modules/campaignion_email_protest/campaignion_email_protest_templates/campaignion_email_protest_templates.features.uuid_node.inc
+++ b/modules/campaignion_email_protest/campaignion_email_protest_templates/campaignion_email_protest_templates.features.uuid_node.inc
@@ -144,7 +144,7 @@ function campaignion_email_protest_templates_uuid_features_default_content() {
         'from_name' => 'default',
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
-<p>Almost there! Just one more click to confirm your support: %confirm_url</p>
+<p>Almost there! Just one more click to confirm your support: [submission:confirm_url]</p>
 <p>Best,<br>
 	Your Supporter Service Team</p>
 ',

--- a/modules/campaignion_email_to_target/campaignion_email_to_target_templates/campaignion_email_to_target_templates.features.uuid_node.inc
+++ b/modules/campaignion_email_to_target/campaignion_email_to_target_templates/campaignion_email_to_target_templates.features.uuid_node.inc
@@ -155,7 +155,7 @@ function campaignion_email_to_target_templates_uuid_features_default_content() {
         'from_name' => 'default',
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
-<p>Almost there! Just one more click to confirm your support: %confirm_url</p>
+<p>Almost there! Just one more click to confirm your support: [submission:confirm_url]</p>
 <p>Best,<br>
 	Your Supporter Service Team</p>
 ',

--- a/modules/campaignion_flexible_form/campaignion_flexible_form_templates/campaignion_flexible_form_templates.features.uuid_node.inc
+++ b/modules/campaignion_flexible_form/campaignion_flexible_form_templates/campaignion_flexible_form_templates.features.uuid_node.inc
@@ -139,7 +139,7 @@ function campaignion_flexible_form_templates_uuid_features_default_content() {
         'from_name' => 'default',
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
-<p>Almost there! Just one more click to confirm your support: %confirm_url</p>
+<p>Almost there! Just one more click to confirm your support: [submission:confirm_url]</p>
 <p>Best,<br>
 	Your Supporter Service Team</p>
 ',

--- a/modules/campaignion_petition/campaignion_petition_templates/campaignion_petition_templates.features.uuid_node.inc
+++ b/modules/campaignion_petition/campaignion_petition_templates/campaignion_petition_templates.features.uuid_node.inc
@@ -139,7 +139,7 @@ function campaignion_petition_templates_uuid_features_default_content() {
         'from_name' => 'default',
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
-<p>Almost there! Just one more click to confirm your support: %confirm_url</p>
+<p>Almost there! Just one more click to confirm your support: [submission:confirm_url]</p>
 <p>Best,<br>
 	Your Supporter Service Team</p>
 ',
@@ -391,7 +391,7 @@ function campaignion_petition_templates_uuid_features_default_content() {
         'from_name' => 'default',
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
-<p>Almost there! Just one more click to confirm your support: %confirm_url</p>
+<p>Almost there! Just one more click to confirm your support: [submission:confirm_url]</p>
 <p>Best,<br>
 	Your Supporter Service Team</p>
 ',
@@ -1046,7 +1046,7 @@ ZW|Zimbabwe
         'from_name' => 'default',
         'from_address' => 'default',
         'template' => '<p>Hallo [submission:values:first_name]!</p>
-<p>Bitte bestätige deine Unterstützung, indem du auf diesen Link klickst: %confirm_url</p>
+<p>Bitte bestätige deine Unterstützung, indem du auf diesen Link klickst: [submission:confirm_url]</p>
 <p>Vielen Dank,<br>
 	dein Supporter Service Team</p>
 ',


### PR DESCRIPTION
In current versions of webform_confirm_email the url token has changed from `%confirm_url` to `[submission:confirm_url]`.
