### PR TITLE
Fix title_display in templates.

### DIFF
--- a/modules/campaignion_donation_type/campaignion_donation_type.features.uuid_node.inc
+++ b/modules/campaignion_donation_type/campaignion_donation_type.features.uuid_node.inc
@@ -399,7 +399,7 @@ y|yearly
           ),
           'currency_code' => 'EUR',
           'private' => 0,
-          'title_display' => NULL,
+          'title_display' => 'none',
           'description' => NULL,
           'conditional_component' => '',
           'conditional_operator' => '=',

--- a/modules/campaignion_email_protest_type/campaignion_email_protest_type.features.uuid_node.inc
+++ b/modules/campaignion_email_protest_type/campaignion_email_protest_type.features.uuid_node.inc
@@ -302,7 +302,7 @@ function campaignion_email_protest_type_uuid_features_default_content() {
           'description' => 'Select an email protest target.',
           'private' => 0,
           'required' => FALSE,
-          'title_display' => NULL,
+          'title_display' => 'none',
           'conditional_component' => '',
           'conditional_operator' => '=',
           'conditional_values' => '',


### PR DESCRIPTION
`NULL` is not a valid value for `#title_display`. `theme_webform_element()` doesn’t render any output (neither for the title nor the element itself) if `#title_display` doesn’t have a valid value.

This was made visible by our earlier changes that add a `webform_element` `#theme_wrapper` to all our custom components.

See:

* moreonion/webform_paymethod_select@ebd85abcdfab1b68c5788611e4cb9b04fadf49de
* moreonion/campaignion#47
