### PR TITLE
[campaignion_conf] webform_email_address_individual

### DIFF
--- a/modules/campaignion_conf/campaignion_conf.info
+++ b/modules/campaignion_conf/campaignion_conf.info
@@ -43,6 +43,7 @@ features[variable][] = share_light_email_message_message
 features[variable][] = share_light_email_message_message_format
 features[variable][] = user_admin_role
 features[variable][] = webform_default_format
+features[variable][] = webform_email_address_individual
 features[variable][] = webform_email_html_capable
 features[variable][] = webform_submission_access_control
 features[variable][] = webform_table

--- a/modules/campaignion_conf/campaignion_conf.strongarm.inc
+++ b/modules/campaignion_conf/campaignion_conf.strongarm.inc
@@ -100,6 +100,13 @@ function campaignion_conf_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'webform_email_address_individual';
+  $strongarm->value = 1;
+  $export['webform_email_address_individual'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'webform_email_html_capable';
   $strongarm->value = 1;
   $export['webform_email_html_capable'] = $strongarm;


### PR DESCRIPTION
This variable is set to 1 so that webform will send mails individually
(in case there are more recipients).

Otherwise there will only be sent one email with all recipients visible
in the To: header.