### PR TITLE
Remove the contact import. It’s now in campaignion_action.

### DIFF
--- a/modules/campaignion_supporter/campaignion_supporter.module
+++ b/modules/campaignion_supporter/campaignion_supporter.module
@@ -11,33 +11,6 @@ use \Drupal\campaignion\NoEmailException;
 use \Drupal\little_helpers\Webform\Submission;
 
 /**
- * Implements hook_campaignion_action_taken().
- */
-function campaignion_supporter_campaignion_action_taken($node, Submission $submissionObj) {
-  $importer = ContactTypeManager::instance()->importer('campaignion_action_taken');
-  try {
-    $contact = $importer->findOrCreateContact($submissionObj);
-  } catch (NoEmailException $e) {
-    // Log the missing email address.
-    $ids = $submissionObj->ids();
-    $args = array('@nid' => $ids['nid'], '@sid' => $ids['sid']);
-    $msg = "Can't import supporter without email-address for Submission(@nid, @sid).";
-    watchdog_exception('campaignion_supporter', $e, $msg, $args);
-    return;
-  }
-  $changed = $importer->import($submissionObj, $contact);
-  // Allow other modules to change the contact.
-  foreach (module_implements('campaignion_supporter_contact_alter') as $module) {
-    $function = $module . '_campaignion_supporter_contact_alter';
-    $changed |= $function($contact, $submissionObj, $node);
-  }
-  if ($changed) {
-    $contact->save();
-  }
-  return $contact;
-}
-
-/**
  * Implements hook_entity_presave().
  */
 function campaignion_supporter_entity_presave($entity, $type) {


### PR DESCRIPTION
All implementations of hook_campaignion_supporter_contact_alter() have
to be migrated to hook_campaignion_action_contact_alter().

Depends on moreonion/campaignion#67