### PR TITLE
[campaignion_supporter] remove supporter tag base field

### DIFF
--- a/modules/campaignion_supporter/campaignion_supporter.features.field_base.inc
+++ b/modules/campaignion_supporter/campaignion_supporter.features.field_base.inc
@@ -275,34 +275,5 @@ function campaignion_supporter_field_default_field_bases() {
     'type' => 'redhen_email',
   );
 
-  // Exported field_base: 'supporter_tags'.
-  $field_bases['supporter_tags'] = array(
-    'active' => 1,
-    'cardinality' => -1,
-    'deleted' => 0,
-    'entity_types' => array(),
-    'field_name' => 'supporter_tags',
-    'global_block_settings' => 1,
-    'indexes' => array(
-      'tid' => array(
-        0 => 'tid',
-      ),
-    ),
-    'locked' => 0,
-    'module' => 'taxonomy',
-    'settings' => array(
-      'allowed_values' => array(
-        0 => array(
-          'vocabulary' => 'supporter_tags',
-          'parent' => 0,
-        ),
-      ),
-      'options_list_callback' => 'i18n_taxonomy_allowed_values',
-      'profile2_private' => FALSE,
-    ),
-    'translatable' => 0,
-    'type' => 'taxonomy_term_reference',
-  );
-
   return $field_bases;
 }

--- a/modules/campaignion_supporter/campaignion_supporter.info
+++ b/modules/campaignion_supporter/campaignion_supporter.info
@@ -35,7 +35,6 @@ features[field_base][] = field_salutation
 features[field_base][] = field_social_network_links
 features[field_base][] = field_title
 features[field_base][] = redhen_contact_email
-features[field_base][] = supporter_tags
 features[field_group][] = group_mp_data|redhen_contact|contact|form
 features[field_instance][] = redhen_contact-contact-field_address
 features[field_instance][] = redhen_contact-contact-field_date_of_birth


### PR DESCRIPTION
The base field is already defined in `campaignion_supporter_tags`, which is a dependency of this module.