### PR TITLE
Add mapping for street_address_2 field

### DIFF
--- a/modules/campaignion_supporter/src/Supporter.php
+++ b/modules/campaignion_supporter/src/Supporter.php
@@ -32,6 +32,7 @@ class Supporter implements ContactTypeInterface {
         new Field\Date('field_date_of_birth',    'date_of_birth'),
         new Field\Address('field_address', array(
           'thoroughfare'        => 'street_address',
+          'premise'             => 'street_address_2',
           'postal_code'         => ['zip_code', 'postcode'],
           'locality'            => 'city',
           'administrative_area' => 'state',
@@ -65,6 +66,7 @@ class Supporter implements ContactTypeInterface {
         $map['gender'] = new WrapperField('field_gender');
         $map['date_of_birth'] = new DateField('field_date_of_birth', '%Y-%m-%d');
         $map['street'] = new KeyedField('field_address', 'thoroughfare');
+        $map['street2'] = new KeyedField('field_address', 'premise');
         $map['country'] = new KeyedField('field_address', 'country');
         $map['zip'] = new KeyedField('field_address', 'postal_code');
         $map['city'] = new KeyedField('field_address', 'locality');
@@ -84,6 +86,7 @@ class Supporter implements ContactTypeInterface {
         $map['GENDER'] = new WrapperField('field_gender');
         $map['DOB'] = new DateField('field_date_of_birth', '%Y-%m-%d');
         $map['STREET'] = new KeyedField('field_address', 'thoroughfare');
+        $map['STREET2'] = new KeyedField('field_address', 'premise');
         $map['COUNTRY'] = new KeyedField('field_address', 'country');
         $map['ZIP'] = new KeyedField('field_address', 'postal_code');
         $map['CITY'] = new KeyedField('field_address', 'locality');
@@ -110,6 +113,7 @@ class Supporter implements ContactTypeInterface {
       case 'campaignion_manage':
         $address_mapping = array(
           'street'  => 'thoroughfare',
+          'street_2' => 'premise',
           'country' => 'country',
           'zip'     => 'postal_code',
           'city'    => 'locality',


### PR DESCRIPTION
Field is present per default on Donations (https://github.com/moreonion/campaignion_starterkit/blob/7.x-1.x/modules/campaignion_donation_type/campaignion_donation_type.features.uuid_node.inc) and Email to target templates (https://github.com/moreonion/campaignion_starterkit/blob/7.x-1.x/modules/campaignion_donation_type/campaignion_donation_type.features.uuid_node.inc), but no mapping exist for that field in Supporter.php. 

This commit is a suggestion of mapping that could be added for the largest email providers.

The merge keys were not tested and might be changed!