### PR TITLE
[Info] Remove unneeded manual DD dependency

### DIFF
--- a/campaignion_starterkit.info
+++ b/campaignion_starterkit.info
@@ -30,9 +30,6 @@ dependencies[] = modernizr
 ; Multilingual
 dependencies[] = i18n_node
 
-; Payment
-dependencies[] = manual_direct_debit
-
 ; Campaignion features
 dependencies[] = campaignion_action_template
 dependencies[] = campaignion_activity

--- a/modules/campaignion_donation_type/campaignion_donation_type.info
+++ b/modules/campaignion_donation_type/campaignion_donation_type.info
@@ -15,6 +15,7 @@ dependencies[] = field_reference_or_redirect
 dependencies[] = file
 dependencies[] = form_builder_webform
 dependencies[] = image
+dependencies[] = manual_direct_debit
 dependencies[] = media
 dependencies[] = node_reference
 dependencies[] = opengraph_meta_upload


### PR DESCRIPTION
Some COTB installations don't have payment activated --> no need for Manual DD dependency